### PR TITLE
removes pointer events from span.title elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -125,7 +125,7 @@ body {
     padding: 2px;
 }
 
-span.title {
+#execs span.title {
     pointer-events: none;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -125,7 +125,9 @@ body {
     padding: 2px;
 }
 
-
+span.title {
+    pointer-events: none;
+}
 
 
 #execs img{


### PR DESCRIPTION
resolves #1 

@nicolasome I'm tagging you here to take a look at the solution I found because I spent way too much time on this and I know you were looking at it! It happens but at least it works now 👍 
 
## Problem

The exec highlight effect didn't work when you moved over the text in front of the images.

## Solution

We want the hover effect to be active whenever the cursor is over the image.

## Implementation

I disabled pointer-events on the span element. This basically lets the pointer event get passed to the next element and gets handled there. We need to be aware of this if we plan to use `<span class="title"> </span> ` elements in other places.

## Testing

I clicked around the page a bunch to make sure everything worked as expected. I also inspected the file changes to ensure I didn't commit something I didn't mean to.